### PR TITLE
Allow overriding default AWS credentials source

### DIFF
--- a/src/Infrastructure/Aws/Sqs.php
+++ b/src/Infrastructure/Aws/Sqs.php
@@ -13,14 +13,14 @@ class Sqs
     private $queuePrefix;
     private $sqs;
 
-    public static function landingiFrankfurt() : Sqs
+    public static function landingiFrankfurt(array $options = []) : Sqs
     {
-        return new self(new SqsRegionClient('eu-central-1'));
+        return new self(new SqsRegionClient('eu-central-1', $options));
     }
 
-    public static function landingiIreland(): Sqs
+    public static function landingiIreland(array $options = []) : Sqs
     {
-        return new self(new SqsRegionClient('eu-west-1'));
+        return new self(new SqsRegionClient('eu-west-1', $options));
     }
 
     public function __construct(SqsClient $client)

--- a/src/Infrastructure/Aws/Sqs/SqsClient.php
+++ b/src/Infrastructure/Aws/Sqs/SqsClient.php
@@ -8,13 +8,16 @@ use Aws\Sqs\SqsClient as BaseClient;
 
 class SqsClient extends BaseClient
 {
-    public function __construct(string $region)
+    public function __construct(string $region, array $options = [])
     {
-        $config = [
-            'credentials' => CredentialProvider::ini('sqs', getenv('AWS_CREDENTIALS_PROFILES_FILE')),
-            'region' => $region,
-            'version' => '2012-11-05'
-        ];
+        $config = array_merge(
+            ['region' => $region, 'version' => '2012-11-05'],
+            $options
+        );
+
+        if (empty($config['credentials']) && !array_key_exists('credentials', $options)) {
+            $config['credentials'] = CredentialProvider::ini('sqs', getenv('AWS_CREDENTIALS_PROFILES_FILE'));
+        }
 
         if ($endpoint = getenv('AWS_SQS_ENDPOINT')) {
             $config['endpoint'] = $endpoint;


### PR DESCRIPTION
So that AWS CredentialsProvider can get credentials straight from the server instance