### PR TITLE
Cache IAM credentials in certain situation

### DIFF
--- a/src/Infrastructure/Aws/Sqs/SqsClient.php
+++ b/src/Infrastructure/Aws/Sqs/SqsClient.php
@@ -10,9 +10,6 @@ class SqsClient extends BaseClient
 {
     public function __construct(string $region, array $options = [])
     {
-        $provider = CredentialProvider::defaultProvider();
-        $provider = CredentialProvider::memoize($provider);
-
         $config = array_merge(
             ['region' => $region, 'version' => '2012-11-05'],
             $options
@@ -20,10 +17,10 @@ class SqsClient extends BaseClient
 
         if (getenv('AWS_CREDENTIALS_PROFILES_FILE')) {
             $config['credentials'] = CredentialProvider::ini('sqs', getenv('AWS_CREDENTIALS_PROFILES_FILE'));
-        }
-
-        if (array_key_exists('credentials', $options) && $config['credentials'] === null) {
-            $config['credentials'] = $provider;
+        } else {
+            $config['credentials'] = CredentialProvider::memoize(
+                CredentialProvider::defaultProvider();
+            );
         }
 
         if ($endpoint = getenv('AWS_SQS_ENDPOINT')) {

--- a/src/Infrastructure/Aws/Sqs/SqsClient.php
+++ b/src/Infrastructure/Aws/Sqs/SqsClient.php
@@ -10,6 +10,9 @@ class SqsClient extends BaseClient
 {
     public function __construct(string $region, array $options = [])
     {
+        $provider = CredentialProvider::defaultProvider();
+        $provider = CredentialProvider::memoize($provider);
+
         $config = array_merge(
             ['region' => $region, 'version' => '2012-11-05'],
             $options
@@ -17,6 +20,10 @@ class SqsClient extends BaseClient
 
         if (getenv('AWS_CREDENTIALS_PROFILES_FILE')) {
             $config['credentials'] = CredentialProvider::ini('sqs', getenv('AWS_CREDENTIALS_PROFILES_FILE'));
+        }
+
+        if (array_key_exists('credentials', $options) && $config['credentials'] === null) {
+            $config['credentials'] = $provider;
         }
 
         if ($endpoint = getenv('AWS_SQS_ENDPOINT')) {

--- a/src/Infrastructure/Aws/Sqs/SqsClient.php
+++ b/src/Infrastructure/Aws/Sqs/SqsClient.php
@@ -19,7 +19,7 @@ class SqsClient extends BaseClient
             $config['credentials'] = CredentialProvider::ini('sqs', getenv('AWS_CREDENTIALS_PROFILES_FILE'));
         } else {
             $config['credentials'] = CredentialProvider::memoize(
-                CredentialProvider::defaultProvider();
+                CredentialProvider::defaultProvider()
             );
         }
 


### PR DESCRIPTION
Odnośnie https://sentry.io/landingi/affiliate/issues/603577742/?query=is:unresolved

Chodzi o to że przy wykonaniu bin/console sdk AWS łączy się bardzo często do 169.254.169.254 który jest aliasem na meta-dane instancji (gdzie przechowywane są jej uprawnienia), ale wg. dokumentacji połączenia te są throttlowane.

SDK posiada natywną obsługę cachowania (memoize) credentiali, więc zmniejszy się ilość requestów do meta-data instancji i tym samym pozbędzie błędu