### PR TITLE
[INT-1317]Use Guzzle in version 6.5 or 7.2 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "doctrine/orm": "^2.6",
         "aws/aws-sdk-php": "^3.52",
         "monolog/monolog": "^1.23",
-        "guzzlehttp/guzzle": "^7.2"
+        "guzzlehttp/guzzle": "^6.5|^7.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5",


### PR DESCRIPTION
Because some of our projects use Guzzle 6 we need change version here to support also some older projects.
Changes between Guzzle 6 and 7 are small and it is compatible with each other: https://github.com/guzzle/guzzle/blob/master/CHANGELOG.md